### PR TITLE
Use v3 sarif upload action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -119,7 +119,7 @@ runs:
         path: results.sarif
 
     - name: Upload SARIF file
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: results.sarif
 


### PR DESCRIPTION
As per [this GitHub blog](https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/) the CodeQL upload v2 workflow is soon to be deprecated. v3 should be a drop-in replacement for this workflow.
