### PR TITLE
chore: update codeql-action/upload-sarif to v3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -119,7 +119,7 @@ runs:
         path: results.sarif
 
     - name: Upload SARIF file
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: results.sarif
 


### PR DESCRIPTION
Hi 👋 . This PR intends to remove deprecation warnings in the job summary. Thanks in advance for checking 🙇 

## Behavior

<img width="800" alt="image" src="https://github.com/user-attachments/assets/63dbd9a7-16e7-4d2e-b8de-686f95ac19d0">

## Changes

This pull request includes an update to the `action.yml` file to use a newer version of the `upload-sarif` action.

Version update:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L122-R122): Updated `github/codeql-action/upload-sarif` from version `v2` to `v3`.