### PR TITLE
Back-porting new features and dependency automation to `shundor/python-bandit-scan`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of action.yml
+    target-branch: "main"
+    rebase-strategy: "disabled"
+    # Labels on pull requests for version updates only
+    labels:
+      - "GitHub"
+      - "Testing"
+    assignees:
+      - "reactive-firewall"
+    commit-message:
+      prefix: "[UPDATE] "
+      include: "scope"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     rebase-strategy: "disabled"
     # Labels on pull requests for version updates only
     labels:
-      - "enhancement"  # choosen as closest exsisting label
+      - "enhancement"  # chosen as closest existing label
     commit-message:
       prefix: "[UPDATE] "
       include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,7 @@ updates:
     rebase-strategy: "disabled"
     # Labels on pull requests for version updates only
     labels:
-      - "GitHub"
-      - "Testing"
-    assignees:
-      - "reactive-firewall"
+      - "enhancement"  # choosen as closest exsisting label
     commit-message:
       prefix: "[UPDATE] "
       include: "scope"

--- a/README.md
+++ b/README.md
@@ -11,12 +11,15 @@ Bandit is a tool designed to find common security issues in Python code. This ac
 To run a bandit scan include a step like this:
 
 ```yaml
-    uses: reactive-firewall/bandit-action@v2
-    with: 
+    uses: reactive-firewall/python-bandit-scan@v2.1
+        with: # optional arguments
+        # Github token of the repository (automatically created by Github)
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information.
         path: "."
         level: high
         confidence: high
-        exit_zero: true           
+        # exit with 0, even with results found
+        exit_zero: true # optional, default is DEFAULT
 ```
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Bandit is a tool designed to find common security issues in Python code. This ac
 To run a bandit scan include a step like this:
 
 ```yaml
-    uses: shundor/bandit-action@v1
+    uses: reactive-firewall/bandit-action@v2
     with: 
         path: "."
         level: high
@@ -67,3 +67,6 @@ The action will create an artifact containing the sarif output.
 ## Credits
 
 - :bow: This action is based on [bandit-action](https://github.com/mdegis/bandit-action) by [Melih Değiş](https://github.com/mdegis/).
+- :bow: This action is _also_ based on [python-bandit-scan](https://github.com/shundor/python-bandit-scan) by [shundor](https://github.com/shundor).
+- :bow: This fork includes fixes proposed by [Kenta Nakase](https://github.com/parroty) and [Thiago Grisolfi](https://github.com/Grisolfi) ... 🎉 but automated by @dependabot
+

--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ Bandit is a tool designed to find common security issues in Python code. This ac
 To run a bandit scan include a step like this:
 
 ```yaml
-    uses: reactive-firewall/python-bandit-scan@v2.1
+    uses: reactive-firewall/python-bandit-scan@v2.2
         with: # optional arguments
         # Github token of the repository (automatically created by Github)
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information.
         path: "."
-        level: high
+        level: low
         confidence: high
         # exit with 0, even with results found
-        exit_zero: true # optional, default is DEFAULT
+        # exit_zero: true # optional, default is DEFAULT
 ```
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Bandit is a tool designed to find common security issues in Python code. This ac
 To run a bandit scan include a step like this:
 
 ```yaml
-    uses: reactive-firewall/python-bandit-scan@v2.2
+    uses: reactive-firewall/python-bandit-scan@v2.3
         with: # optional arguments
         # Github token of the repository (automatically created by Github)
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information.
@@ -71,5 +71,5 @@ The action will create an artifact containing the sarif output.
 
 - :bow: This action is based on [bandit-action](https://github.com/mdegis/bandit-action) by [Melih Değiş](https://github.com/mdegis/).
 - :bow: This action is _also_ based on [python-bandit-scan](https://github.com/shundor/python-bandit-scan) by [shundor](https://github.com/shundor).
-- :bow: This fork includes fixes proposed by [Kenta Nakase](https://github.com/parroty) and [Thiago Grisolfi](https://github.com/Grisolfi) ... 🎉 but automated by @dependabot
+- :bow: This fork includes fixes proposed by [Kenta Nakase](https://github.com/parroty) and [Thiago Grisolfi](https://github.com/Grisolfi) and ["MrFired"](https://github.com/MrFired) ... 🎉 but automated by [@dependabot[bot]](https://github.com/apps/dependabot)
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ To run a bandit scan include a step like this:
 
 ```yaml
     uses: shundor/bandit-action@v1
-    with: 
+    with:
         path: "."
         level: high
         confidence: high
-        exit_zero: true           
+        exit_zero: true
 ```
 
 ## Inputs
@@ -67,3 +67,4 @@ The action will create an artifact containing the sarif output.
 ## Credits
 
 - :bow: This action is based on [bandit-action](https://github.com/mdegis/bandit-action) by [Melih Değiş](https://github.com/mdegis/).
+- :bow: This action also includes fixes proposed by [Kenta Nakase](https://github.com/parroty) and [Thiago Grisolfi](https://github.com/Grisolfi) and ["MrFired"](https://github.com/MrFired) ... 🎉 but automated by [@dependabot[bot]](https://github.com/apps/dependabot)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Bandit is a tool designed to find common security issues in Python code. This ac
 To run a bandit scan include a step like this:
 
 ```yaml
-    uses: shundor/bandit-action@v1
+    uses: shundor/python-bandit-scan@v1
     with: # optional arguments
       path: "."
       level: high

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To run a bandit scan include a step like this:
       level: high
       confidence: high
       # exit with 0, even with results found
-      exit_zero: true  # optional, default is DEFAULT
+      exit_zero: true  # optional, default is DEFAULT (exit with results-based value)
 ```
 
 ## Inputs

--- a/action.yml
+++ b/action.yml
@@ -119,7 +119,7 @@ runs:
         path: results.sarif
 
     - name: Upload SARIF file
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: results.sarif
 

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Bandit Scan'
+name: 'Python Bandit Scan'
 description: 'Bandit Scan'
 branding:
   icon: arrow-left
@@ -113,7 +113,7 @@ runs:
         INPUT_INI_PATH: ${{ inputs.ini_path }}        
 
     - name: Upload artifact
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@v4
       with:
         name: results.sarif
         path: results.sarif

--- a/action.yml
+++ b/action.yml
@@ -120,7 +120,7 @@ runs:
         overwrite: true
 
     - name: Upload SARIF file
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: results.sarif
 

--- a/action.yml
+++ b/action.yml
@@ -113,10 +113,11 @@ runs:
         INPUT_INI_PATH: ${{ inputs.ini_path }}        
 
     - name: Upload artifact
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@v4
       with:
         name: results.sarif
         path: results.sarif
+        overwrite: true
 
     - name: Upload SARIF file
       uses: github/codeql-action/upload-sarif@v2

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: 'path to a .bandit file that supplies command line arguments'
     required: false
     default: 'DEFAULT'
+  config_path:
+    description: 'path to a YAML or TOML file that supplies command line arguments'
+    required: false
+    default: 'DEFAULT'
   GITHUB_TOKEN:
     description: 'Github token of the repository (automatically created by Github)'
     required: true
@@ -102,7 +106,13 @@ runs:
         else
             INI_PATH="--ini $INPUT_INI_PATH"
         fi
-        bandit -f sarif -o results.sarif -r $INPUT_PATH $LEVEL $CONFIDENCE $EXCLUDED_PATHS $EXIT_ZERO $SKIPS $INI_PATH
+
+        if [ "$INPUT_CONFIG_PATH" == "DEFAULT" ]; then
+            CONFIG_PATH=""
+        else
+            CONFIG_PATH="-c $INPUT_CONFIG_PATH"
+        fi
+        bandit -f sarif -o results.sarif -r $INPUT_PATH $LEVEL $CONFIDENCE $EXCLUDED_PATHS $EXIT_ZERO $SKIPS $INI_PATH $CONFIG_PATH
       env:
         INPUT_PATH: ${{ inputs.path }}
         INPUT_LEVEL: ${{ inputs.level }}
@@ -110,7 +120,8 @@ runs:
         INPUT_EXCLUDED_PATHS: ${{ inputs.excluded_paths }}
         INPUT_EXIT_ZERO: ${{ inputs.exit_zero }}
         INPUT_SKIPS: ${{ inputs.skips }}
-        INPUT_INI_PATH: ${{ inputs.ini_path }}        
+        INPUT_INI_PATH: ${{ inputs.ini_path }}
+        INPUT_CONFIG_PATH: ${{ inputs.config_path }}
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4

--- a/action.yml
+++ b/action.yml
@@ -107,12 +107,20 @@ runs:
             INI_PATH="--ini $INPUT_INI_PATH"
         fi
 
+        CONFIG_PATH_ARG=""
         if [ "$INPUT_CONFIG_PATH" == "DEFAULT" ]; then
+            # Clear both
             CONFIG_PATH=""
+            CONFIG_PATH_ARG=""
+            unset CONFIG_PATH 2>dev/null || true  # also try to unset
         else
-            CONFIG_PATH="-c $INPUT_CONFIG_PATH"
+            if [ -n "$INPUT_CONFIG_PATH" ] ; then
+              # Set both (but let bandit validate its own arguments)
+              CONFIG_PATH="$INPUT_CONFIG_PATH" # quote paths on assignment
+              CONFIG_PATH_ARG="-c"
+            fi
         fi
-        bandit -f sarif -o results.sarif -r $INPUT_PATH $LEVEL $CONFIDENCE $EXCLUDED_PATHS $EXIT_ZERO $SKIPS $INI_PATH $CONFIG_PATH
+        bandit -f sarif -o results.sarif -r $INPUT_PATH $LEVEL $CONFIDENCE $EXCLUDED_PATHS $EXIT_ZERO $SKIPS $INI_PATH $CONFIG_PATH_ARG ${CONFIG_PATH:-}
       env:
         INPUT_PATH: ${{ inputs.path }}
         INPUT_LEVEL: ${{ inputs.level }}


### PR DESCRIPTION
# Patch Notes

## Back-port of new features

 * 🗒️ **Introduced** an optional `config_path` parameter for the Bandit Scan action, allowing users to specify a configuration file for command line arguments. Credit: @MrFired
 * 🤖 **Automated** dependency maintainability via BCP use of GitHubs own @dependabot
   - @dependabot will periodically open PRs to upgrade dependencies to help ease the workload of maintainers (eg. @abirismyname)
   
## Fixes and Corrections

 * 🩹 **Fixed** an untracked issue where re-running the GitHub Action could error when attempting to upload the `results.sarif` artifact. Namely, added an option to overwrite existing artifacts during upload when needed. This overwrite behavior _only_ impacts duplicates that would otherwise fail instead.
 * ✏️ **Updated** the usage example in the `README.md` to use the correct name for the `shundor/python-bandit-scan` GitHub Action (Hopefully this helps resolve issues like shundor/python-bandit-scan#1)
 * 🚀 **Includes** version bumps for action dependancies
> ### `github/code-action/upload-artifact` -> `v4`
>
> * Updating to `actions/upload-artifact@v4` brings significant changes we should be aware of. The maintainers have noted that version 4 introduces breaking changes:
> 
> * **GitHub Enterprise Server (GHES) Compatibility**: Support for GHES versions prior to 3.5 has been discontinued. If you're using an older GHES version, this update might not be compatible.
> * **Default Behavior Adjustments**: There may be changes to default configurations, such as the default value for retention-days. Deprecated inputs or features might have been removed as well.
> 
> For a comprehensive understanding of these impacts and to ensure seamless integration, please review the maintainers' notes in the [upload-artifact project README](https://github.com/actions/upload-artifact#actionsupload-artifact)

## Possibly Impacted GHI

 - [x] Attempts to resolve shundor/python-bandit-scan#1 (by updating directions)
 - [x] Carefully ensures no regression with PRs #2 #3 #4 & #5 while also implements automation to reduce need for similar manual efforts going forward.
 
## Conclusion and Request for Comments

Thank you for reviewing this pull request! Your feedback is invaluable in ensuring that these changes align with the project's goals and maintain high quality. 

I would especially appreciate comments from the following community members:

- @abirismyname: As this is ultimately your project, your insights (or even questions) would be greatly appreciated. 🙉
- @MrFired: Your insights on the `config_path` feature would be greatly appreciated. 🙊
- @SamMorrowDrums, @felickz: Since you were both previously involved with dependency efforts (eg shundor/python-bandit-scan#2), your thoughts on the integration of @dependabot would be helpful. (also @abirismyname too of-course :bow:)

Please feel free to share any additional thoughts or concerns you may have. Looking forward to your feedback!